### PR TITLE
Mark vue-cli 3 as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We plan to invest time in developing a more robust regression testing system to 
 
 ### vue-cli 3.0
 
-* **Status:** RC
+* **Status:** stable
 * **Goal:** upgrade `vue-cli` to address project upgrade issues and provide even smoother DX.
 * [Docs](https://cli.vuejs.org)
 


### PR DESCRIPTION
Per https://github.com/vuejs/vue-cli/releases

Not sure if 'stable' is the preferred term, but wanted to note that it's not in RC anymore.